### PR TITLE
prepare for publishing to crates.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2022-04-19
+
+### Added
+
+- A basic terminal emulator on text buffer or frame buffer.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,18 @@
 [package]
-name = "rcore-console"
+name = "embedded-term"
 version = "0.1.0"
 authors = [
     "Runji Wang <wangrunji0408@163.com>",
     "Yuekai Jia <equation618@gmail.com>",
     "Jiajie Chen <jiegec@qq.com>"
 ]
-edition = "2018"
-description = "The virtual console embedded in rCore kernel: receive text input and print to a framebuffer."
+edition = "2021"
+description = "Terminal emulator on embedded-graphics."
+keywords = ["terminal", "no-std"]
+categories = ["embedded", "gui", "no-std"]
+homepage = "https://github.com/rcore-os/embedded-term"
+repository = "https://github.com/rcore-os/embedded-term"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,7 +25,8 @@ lazy_static = "1.4"
 
 [dev-dependencies]
 embedded-graphics-simulator = "0.3"
-env_logger = "0.7"
+embedded-graphics-core = "0.3"
+env_logger = "0.9"
 libc = "0.2"
 pty = "0.2"
 mio = "0.6"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2020 rCore Developers
+Copyright (c) 2019-2022 rCore Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# rcore-console
+# Embedded Terminal
 
-[![Actions Status](https://github.com/rcore-os/rcore-console/workflows/CI/badge.svg)](https://github.com/rcore-os/rcore-console/actions)
+[![Crate](https://img.shields.io/crates/v/embedded-term.svg)](https://crates.io/crates/embedded-term)
+[![Docs](https://docs.rs/embedded-term/badge.svg)](https://docs.rs/embedded-term)
+[![Actions Status](https://github.com/rcore-os/embedded-term/workflows/CI/badge.svg)](https://github.com/rcore-os/embedded-term/actions)
 
-The virtual console embedded in rCore kernel.
+A terminal emulator on [embedded-graphics][].
+
+This crate is `no_std` compatible. It is suitable for embedded systems and OS kernels.
+
+[embedded-graphics]: https://github.com/embedded-graphics/embedded-graphics
 
 ## Run example
 
@@ -23,3 +29,24 @@ cargo run --example pty htop
 ```
 
 TODO: documents and tests
+
+## Optional features
+
+- `log`: Enable built-in logging.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0
+   ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license
+   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("cargo:rerun-if-env-changed=RUST_LOG");
-}

--- a/examples/pty.rs
+++ b/examples/pty.rs
@@ -2,15 +2,15 @@ use std::io::{stdin, Read, Write};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::{cell::RefCell, convert::Infallible, fs::File, process::Command, time::Duration};
 
+use embedded_graphics_core::{pixelcolor::Rgb888, prelude::*};
 use embedded_graphics_simulator::{
     OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
 };
+use embedded_term::Console;
 use libc::{self, winsize};
 use mio::{unix::EventedFd, Events, Poll, PollOpt, Ready, Token};
 use pty::fork::Fork;
 use termios::{cfmakeraw, tcsetattr, Termios, TCSANOW};
-
-use rcore_console::{Console, DrawTarget, OriginDimensions, Pixel, Rgb888, Size};
 
 const DISPLAY_SIZE: Size = Size::new(800, 600);
 

--- a/examples/replay.rs
+++ b/examples/replay.rs
@@ -2,11 +2,11 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{convert::Infallible, fmt::Write, thread};
 
+use embedded_graphics_core::{pixelcolor::Rgb888, prelude::*};
 use embedded_graphics_simulator::{
     OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
 };
-
-use rcore_console::{Console, DrawTarget, OriginDimensions, Pixel, Rgb888, Size};
+use embedded_term::Console;
 
 const DISPLAY_SIZE: Size = Size::new(1280, 720);
 

--- a/examples/rterm.rs
+++ b/examples/rterm.rs
@@ -1,7 +1,8 @@
+use embedded_graphics_core::{pixelcolor::Rgb888, prelude::*};
 use embedded_graphics_simulator::{
     OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
 };
-use rcore_console::{Console, DrawTarget, OriginDimensions, Pixel, Rgb888, Size};
+use embedded_term::Console;
 
 use std::convert::Infallible;
 use std::io::Read;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,16 @@
-//! The virtual console embedded in rCore kernel.
+//! Terminal emulator on [embedded-graphics].
+//!
+//! The crate is `no_std` compatible. It is suitable for embedded systems and OS kernels.
 //!
 //! The [`Console`] can be built on top of either a [`TextBuffer`] or a frame buffer ([`DrawTarget`]).
+//! For example, the [VGA text mode] has a text buffer, while the graphic mode has a frame buffer.
 //!
-//! This crate is no_std compatible.
-//!
-//! It can be tested in SDL2 with the help of [`embedded_graphics_simulator`](https://docs.rs//embedded-graphics/#simulator) crate.
+//! It can be tested in SDL2 with the help of [`embedded_graphics_simulator`](https://docs.rs//embedded-graphics/#simulator).
 //! See examples for details.
+//!
+//! [embedded-graphics]: embedded_graphics
+//! [`DrawTarget`]: embedded_graphics::draw_target::DrawTarget
+//! [VGA text mode]: https://en.wikipedia.org/wiki/VGA_text_mode
 
 #![no_std]
 #![deny(unsafe_code)]
@@ -23,11 +28,6 @@ extern crate log;
 mod log;
 
 pub use console::{Console, ConsoleOnGraphic};
-pub use embedded_graphics::{
-    self,
-    pixelcolor::Rgb888,
-    prelude::{DrawTarget, OriginDimensions, Pixel, Size},
-};
 pub use graphic::TextOnGraphic;
 pub use text_buffer::TextBuffer;
 pub use text_buffer_cache::TextBufferCache;


### PR DESCRIPTION
This PR adds necessary files and prepares the crate for publishing to crates.io.

To better demonstrate the functionality of this crate, I suggest renaming it to `embedded-term`.

Any other comments? @equation314 